### PR TITLE
fix: add n_colors as parameter to save pkl file

### DIFF
--- a/colors.py
+++ b/colors.py
@@ -44,12 +44,12 @@ def get_closest_pixels(img, colors=None):
     logging.debug(colors)
     return colors
 
-def get_colors(image, n_colors=3, method="kmeans"):
+def get_colors(image, n_colors=3, method="kmeans", save=False):
     color_clusters = None
     if method == "kmeans":
-        color_clusters = get_colors_kmeans(image, n_colors)
+        color_clusters = get_colors_kmeans(image, n_colors, save=save)
     elif method == "quantization":
-        color_clusters = get_colors_quantization(image, n_colors)
+        color_clusters = get_colors_quantization(image, n_colors, save=save)
     else:
         raise ValueError("Unknow method")
 
@@ -79,7 +79,7 @@ def get_colors_kmeans(image, n_clusters=3, resize_method="bilinear", new_size=(2
         logging.debug(color_cluster.labels_)
 
         if save:
-            save_file(pkl_file, centroids)
+            save_file(pkl_file, n_clusters, centroids)
     return centroids
 
 def get_image_clusters(image_centroids, n_clusters=3):
@@ -103,7 +103,7 @@ def load_file(file):
         data = pkl.load(f)
     return data
 
-def save_file(file, data):
+def save_file(file, n_clusters, data):
     logging.info("Saving file {}".format(os.path.basename(file)))
     with open(file, 'wb') as f:
         pkl.dump(data, f)

--- a/main.py
+++ b/main.py
@@ -11,13 +11,13 @@ from hist import *
 logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.DEBUG)
 
 FILE = sys.argv[1]
-N_COLORS = 5
+N_COLORS = sys.argv[2]
 
 if os.path.isfile(FILE):
     logging.debug("Argument is a file")
     if not os.path.isabs(FILE):
         FILE = os.path.join(os.getcwd(), FILE)
-    cluster = get_colors(FILE, n_colors=N_COLORS)
+    cluster = get_colors(FILE, n_colors=N_COLORS, save=True)
     print(cluster)
     show_colors(cluster)
 elif os.path.isdir(FILE):


### PR DESCRIPTION
now, instead of saving the pkl file just with the original image name, it will
also use the number of clusters, so loading won't crash if a different number of
clusters is used.

Changelog:
* fix `get_colors` signature and implementation
* fix `get_colors_kmeans` signature and implementation
* fix `get_colors_quantization` signature 
* fix `save_file` signature and implementation
* change `N_COLORS` to be a `sys.argv` parameter so my tests would be easier

closes #4 